### PR TITLE
Add online gait training loop

### DIFF
--- a/AE/simple_autoencoder.py
+++ b/AE/simple_autoencoder.py
@@ -5,6 +5,7 @@ import numpy as np
 import matplotlib.pyplot as plt
 import os
 from datetime import datetime
+from typing import Optional
 
 class CVAEEncoder(nn.Module):
     def __init__(self, layer_sizes, latent_space, activation=nn.ReLU):
@@ -46,6 +47,7 @@ class BasicAutoencoder(nn.Module):
         self.joints = joints
         self.timesteps = timesteps
         self.condition_size = condition_size
+        self.latent_size = latent_size
         input_size = joints * timesteps
         full_encoder_sizes = [input_size + condition_size] + layer_sizes
         self.encoder = CVAEEncoder(full_encoder_sizes, latent_size)
@@ -75,6 +77,29 @@ class BasicAutoencoder(nn.Module):
         condition_size = ...  # Extract condition_size from model_str
         output_activation = ...  # Extract output_activation from model_str if available
         return cls(joints, timesteps, latent_size, layer_sizes, condition_size, output_activation, learning_rate)
+
+    def _flatten_controls(self, controls: torch.Tensor) -> torch.Tensor:
+        """Ensure the control batch is a 2D tensor of shape [batch, timesteps * joints]."""
+        if controls.dim() == 3:
+            if controls.size(1) != self.timesteps or controls.size(2) != self.joints:
+                raise ValueError(
+                    f"Control tensor has invalid shape {controls.shape}; expected [batch, {self.timesteps}, {self.joints}]."
+                )
+            return controls.view(controls.size(0), -1)
+        if controls.dim() == 2:
+            return controls
+        raise ValueError("Controls must be a 2D or 3D tensor.")
+
+    def _prepare_condition(self, condition: Optional[torch.Tensor], batch_size: int, device: torch.device) -> Optional[torch.Tensor]:
+        if condition is None:
+            return None
+        if condition.dim() == 1:
+            condition = condition.unsqueeze(-1)
+        if condition.dim() != 2:
+            raise ValueError("Condition tensor must be 2D with shape [batch, condition_size].")
+        if condition.size(0) != batch_size:
+            raise ValueError(f"Condition batch size {condition.size(0)} does not match controls batch size {batch_size}.")
+        return condition.to(device)
 
     def forward(self, x, condition=None, evaluate=False):
         if x.dim() != 2:
@@ -113,10 +138,10 @@ class BasicAutoencoder(nn.Module):
 
     def train_single_epoch(self, train_controls, condition, device):
         self.train()
-        train_controls = train_controls.to(device)  # Shape: [batch_size, input_size]
-        condition = condition.to(device) if condition is not None else None
+        train_controls = self._flatten_controls(train_controls).to(device)
+        condition = self._prepare_condition(condition, train_controls.size(0), device)
         self.optimizer.zero_grad()
-        
+
         # Debug: Print shapes and check for NaNs
         print(f"Train controls shape: {train_controls.shape}")
         print(f"Condition shape: {condition.shape if condition is not None else None}")
@@ -142,7 +167,7 @@ class BasicAutoencoder(nn.Module):
             loss.backward()
             torch.nn.utils.clip_grad_norm_(self.parameters(), max_norm=1.0)
             self.optimizer.step()
-        
+
         return loss.item(), latent_representation
 
     def train_model(self, train_controls, val_controls, device, epochs=100, visualize_reconstruction=False, results_dir=None, condition=None):
@@ -192,6 +217,40 @@ class BasicAutoencoder(nn.Module):
             torch.save(self.state_dict(), os.path.join(results_dir, 'trained_autoencoder.pth'))
 
         return train_losses, val_losses
+
+    def online_update(self, controls: torch.Tensor, condition: Optional[torch.Tensor] = None) -> float:
+        """Perform a single gradient update using a micro-batch of controls."""
+        self.train()
+        device = next(self.parameters()).device
+        controls = self._flatten_controls(controls).to(device)
+        condition = self._prepare_condition(condition, controls.size(0), device)
+        self.optimizer.zero_grad()
+        decoded, _, mean, log_variation = self.forward(controls, condition)
+        loss = self.loss_function(controls, decoded, mean, log_variation)
+        loss.backward()
+        torch.nn.utils.clip_grad_norm_(self.parameters(), max_norm=1.0)
+        self.optimizer.step()
+        return loss.item()
+
+    @torch.no_grad()
+    def sample_latent(self, batch_size: int, device: Optional[torch.device] = None) -> torch.Tensor:
+        if device is None:
+            device = next(self.parameters()).device
+        return torch.randn(batch_size, self.latent_size, device=device)
+
+    @torch.no_grad()
+    def decode_latent(self, latent: torch.Tensor, condition: Optional[torch.Tensor] = None) -> torch.Tensor:
+        if latent.dim() != 2 or latent.size(1) != self.latent_size:
+            raise ValueError(f"Latent tensor must have shape [batch, {self.latent_size}].")
+        device = latent.device
+        if condition is not None:
+            if condition.dim() == 1:
+                condition = condition.unsqueeze(-1)
+            if condition.dim() != 2 or condition.size(0) != latent.size(0):
+                raise ValueError("Condition tensor must have shape [batch, condition_size].")
+            latent = torch.cat((latent, condition.to(device)), dim=-1)
+        decoded = self.decoder(latent)
+        return decoded.view(decoded.size(0), self.timesteps, self.joints)
 
     def evaluate(self, input_batch, device, condition=None):
         self.eval()

--- a/docs/real_time_gait_strategy.md
+++ b/docs/real_time_gait_strategy.md
@@ -1,0 +1,37 @@
+# Real-Time Gait Discovery and Dynamics Learning Roadmap
+
+This document sketches concrete engineering steps to extend the current offline Variational Autoencoder (VAE) training pipeline toward online, real-time gait discovery and dynamics learning while a robot is walking.
+
+## 1. Streamed Data Interface
+
+* Replace the current SQL query that bulk-loads trajectories before training with a streaming data API.
+* Implement a producer (e.g., `EnvSampler`) that collects the most recent window of sensor/state/action tuples from the simulator or robot and pushes them to a ring buffer on every control tick.
+* Update the training loop so that `BasicAutoencoder.train_single_epoch` consumes micro-batches from this buffer instead of the entire static tensor. Use asynchronous CUDA streams to overlap collection and training.
+
+## 2. Latent Dynamics Head
+
+* Augment `BasicAutoencoder` with a small latent dynamics model (e.g., GRU or linear state-space layer) that predicts the next latent vector from the previous latent and current action. Train it jointly with the reconstruction loss and a prediction loss between predicted and actual latent states.
+* Export both the decoder and dynamics head so that a Model Predictive Control (MPC) or shooting method can plan actions directly in latent space during runtime.
+
+## 3. Continual / Online Optimisation
+
+* Use experience replay with prioritisation to retain high-reward trajectories while allowing fresh samples to dominate gradients.
+* Adopt low learning rate Adam or RMSProp with gradient clipping already present to stabilise online updates, and add EMA (exponential moving average) weights for deployment.
+
+## 4. Real-Time Inference Path
+
+* Preload the trained decoder on the control computer and expose a `decode(latent, condition)` interface that runs in under the control-loop latency budget (e.g., <1 ms on GPU).
+* Convert the PyTorch modules to TorchScript or TensorRT for deterministic latency when executing on embedded hardware.
+
+## 5. Safety Guards
+
+* Implement predictive checks that reject latent rollouts when the decoder reconstructs torques outside joint limits or when the latent dynamics head predicts instability, falling back to a safe gait library.
+
+## 6. Evaluation Protocol
+
+* Create benchmarks that measure convergence speed of online updates versus offline retraining, both in simulation and (if available) on hardware logs.
+
+## 7. Prototype Implementation
+
+An initial reference implementation of this online loop now lives in [`online_training.py`](../online_training.py). It streams new gaits as they are executed, perturbs them for exploration, and applies `BasicAutoencoder.online_update` on every rollout while maintaining a replay buffer for continual rehearsal. Results, best-performing gaits, and updated weights are written to `results/online_<timestamp>/` for inspection.
+

--- a/online_training.py
+++ b/online_training.py
@@ -1,0 +1,228 @@
+"""Online gait generation and training loop for the VAE-based controller.
+
+This script streams trajectories from the walking policy back into the
+autoencoder so it can adapt while the robot is exploring.  The workflow is:
+
+1. Warm up the replay buffer with random gaits to avoid a cold start.
+2. Sample latent codes from the autoencoder to decode nominal gaits.
+3. Perturb each decoded gait with Gaussian noise so the robot keeps exploring.
+4. Execute each gait in the environment, collect rewards, and immediately
+   update the autoencoder using the latest trajectory (online update).
+5. Maintain a replay buffer so the network rehearses high-reward motions while
+   still prioritising fresh experience.
+
+Usage:
+
+```
+python online_training.py \
+    --config config/simpleAE.yaml \
+    --iterations 50 \
+    --perturbations 4
+```
+
+The script stores training logs, the best gait that was discovered, and the
+updated model weights under `results/online_<timestamp>/`.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import random
+import time
+from collections import deque
+from dataclasses import dataclass, field
+from typing import Deque, Dict, List, Optional, Tuple
+
+import gym
+import torch
+import yaml
+
+import ant_env.environment  # noqa: F401 - registers CustomAnt-v3 on import
+from AE.simple_autoencoder import BasicAutoencoder
+from generate_data import evaluate_control_sequence
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Online training loop for gait discovery")
+    parser.add_argument("--config", type=str, default="config/simpleAE.yaml", help="Path to the model configuration YAML")
+    parser.add_argument("--env", type=str, default="CustomAnt-v3", help="Gym environment id to use for rollouts")
+    parser.add_argument("--config-key", type=str, default="AntEnv_v3", help="Configuration key inside the YAML file")
+    parser.add_argument("--iterations", type=int, default=50, help="Number of online optimisation iterations")
+    parser.add_argument("--perturbations", type=int, default=4, help="Number of perturbations per nominal gait")
+    parser.add_argument("--warmup-rollouts", type=int, default=32, help="Random rollouts to seed the replay buffer")
+    parser.add_argument("--batch-size", type=int, default=32, help="Mini-batch size for replay updates")
+    parser.add_argument("--buffer-size", type=int, default=2048, help="Replay buffer capacity")
+    parser.add_argument("--updates-per-iter", type=int, default=2, help="Replay updates to run after each iteration")
+    parser.add_argument("--perturb-std", type=float, default=0.1, help="Standard deviation for Gaussian gait perturbations")
+    parser.add_argument("--max-action", type=float, default=1.0, help="Clamp actions within [-max_action, max_action]")
+    parser.add_argument("--seed", type=int, default=0, help="Random seed")
+    parser.add_argument("--device", type=str, default=None, help="Device to run the model on (auto-detected if omitted)")
+    return parser.parse_args()
+
+
+def load_config(path: str, key: str) -> Dict:
+    with open(path, "r") as handle:
+        config = yaml.safe_load(handle)
+    if key not in config:
+        raise KeyError(f"Configuration key '{key}' not found in {path}")
+    return config[key]
+
+
+@dataclass
+class ReplayBuffer:
+    capacity: int
+    buffer: Deque[Tuple[torch.Tensor, float]] = field(default_factory=deque)
+
+    def __post_init__(self) -> None:
+        self.buffer = deque(maxlen=self.capacity)
+
+    def add(self, controls: torch.Tensor, reward: float) -> None:
+        self.buffer.append((controls.detach().clone(), float(reward)))
+
+    def sample(self, batch_size: int) -> torch.Tensor:
+        batch = random.sample(self.buffer, min(batch_size, len(self.buffer)))
+        return torch.stack([item[0] for item in batch], dim=0)
+
+    def __len__(self) -> int:  # pragma: no cover - simple accessor
+        return len(self.buffer)
+
+
+class OnlineGaitTrainer:
+    def __init__(self, args: argparse.Namespace) -> None:
+        random.seed(args.seed)
+        torch.manual_seed(args.seed)
+
+        config = load_config(args.config, args.config_key)
+        self.joints = config["joints"]
+        self.timesteps = config["timesteps"]
+        self.condition_size = config.get("condition_size", 0)
+
+        device_str = args.device or ("cuda" if torch.cuda.is_available() else "cpu")
+        self.device = torch.device(device_str)
+
+        self.autoencoder = BasicAutoencoder(
+            joints=self.joints,
+            timesteps=self.timesteps,
+            latent_size=config["latent_size"],
+            layer_sizes=config["layer_sizes"],
+            condition_size=self.condition_size,
+        ).to(self.device)
+
+        self.env = gym.make(args.env)
+        self.replay = ReplayBuffer(args.buffer_size)
+        self.batch_size = args.batch_size
+        self.num_perturbations = args.perturbations
+        self.updates_per_iter = args.updates_per_iter
+        self.perturb_std = args.perturb_std
+        self.max_action = args.max_action
+        self.warmup_rollouts = args.warmup_rollouts
+
+        timestamp = time.strftime("%Y%m%d_%H%M%S")
+        self.results_dir = os.path.join("results", f"online_{timestamp}")
+        os.makedirs(self.results_dir, exist_ok=True)
+
+        self.training_log: List[Dict] = []
+        self.best_reward = float("-inf")
+        self.best_gait: Optional[torch.Tensor] = None
+
+    def clamp_controls(self, controls: torch.Tensor) -> torch.Tensor:
+        return torch.clamp(controls, -self.max_action, self.max_action)
+
+    def rollout(self, controls: torch.Tensor) -> Tuple[float, Dict]:
+        controls = self.clamp_controls(controls).cpu().float()
+        flat = controls.view(-1)
+        info = evaluate_control_sequence(flat, self.env, self.joints)
+        rewards = info.get("rewards_over_time", [])
+        total_reward = float(sum(rewards)) if rewards else float(info.get("reward", 0.0))
+        return total_reward, info
+
+    def warmup(self) -> None:
+        if self.warmup_rollouts <= 0:
+            return
+        for _ in range(self.warmup_rollouts):
+            random_controls = torch.empty(self.timesteps, self.joints).uniform_(-self.max_action, self.max_action)
+            reward, _ = self.rollout(random_controls)
+            self.replay.add(random_controls, reward)
+            self.autoencoder.online_update(random_controls.unsqueeze(0).to(self.device))
+
+    def generate_nominal_gait(self) -> torch.Tensor:
+        latent = self.autoencoder.sample_latent(1, device=self.device)
+        decoded = self.autoencoder.decode_latent(latent)
+        return decoded.squeeze(0).detach().cpu()
+
+    def perturb(self, controls: torch.Tensor) -> torch.Tensor:
+        noise = torch.randn_like(controls) * self.perturb_std
+        return self.clamp_controls(controls + noise)
+
+    def online_step(self, iteration: int) -> Dict:
+        nominal = self.generate_nominal_gait()
+        candidates = [nominal] + [self.perturb(nominal) for _ in range(self.num_perturbations)]
+
+        losses: List[float] = []
+        rewards: List[float] = []
+
+        for controls in candidates:
+            reward, _ = self.rollout(controls)
+            rewards.append(reward)
+            self.replay.add(controls, reward)
+            loss = self.autoencoder.online_update(controls.unsqueeze(0).to(self.device))
+            losses.append(loss)
+            if reward > self.best_reward:
+                self.best_reward = reward
+                self.best_gait = controls.detach().clone()
+
+        for _ in range(self.updates_per_iter):
+            if len(self.replay) < self.batch_size:
+                break
+            batch = self.replay.sample(self.batch_size).to(self.device)
+            replay_loss = self.autoencoder.online_update(batch)
+            losses.append(replay_loss)
+
+        summary = {
+            "iteration": iteration,
+            "mean_reward": float(sum(rewards) / len(rewards)),
+            "max_reward": max(rewards),
+            "mean_loss": float(sum(losses) / len(losses)),
+            "buffer_size": len(self.replay),
+        }
+        self.training_log.append(summary)
+        return summary
+
+    def save_results(self) -> None:
+        model_path = os.path.join(self.results_dir, "autoencoder_online.pth")
+        torch.save(self.autoencoder.state_dict(), model_path)
+
+        if self.best_gait is not None:
+            best_path = os.path.join(self.results_dir, "best_gait.pt")
+            torch.save({"controls": self.best_gait, "reward": self.best_reward}, best_path)
+
+        log_path = os.path.join(self.results_dir, "training_log.json")
+        with open(log_path, "w") as handle:
+            json.dump(self.training_log, handle, indent=2)
+
+    def close(self) -> None:
+        self.env.close()
+
+
+def main() -> None:
+    args = parse_args()
+    trainer = OnlineGaitTrainer(args)
+    try:
+        trainer.warmup()
+        for iteration in range(1, args.iterations + 1):
+            summary = trainer.online_step(iteration)
+            print(
+                f"Iteration {iteration:03d} | Mean Reward: {summary['mean_reward']:.3f} | "
+                f"Max Reward: {summary['max_reward']:.3f} | Mean Loss: {summary['mean_loss']:.6f} | "
+                f"Buffer: {summary['buffer_size']}"
+            )
+    finally:
+        trainer.save_results()
+        trainer.close()
+
+
+if __name__ == "__main__":
+    main()
+


### PR DESCRIPTION
## Summary
- extend `BasicAutoencoder` with helpers for flattening batches, online micro-updates, and latent sampling/decoding utilities
- add an `online_training.py` script that generates, perturbs, and evaluates gaits while continually updating the autoencoder from streamed experience
- document the prototype online-training entry point in the real-time gait strategy notes

## Testing
- python -m compileall online_training.py AE/simple_autoencoder.py

------
https://chatgpt.com/codex/tasks/task_e_68da42362774832aac3b9f6c9d284bd5